### PR TITLE
Added speedtest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /build
+/CMakeLists.txt.user

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,3 +53,6 @@ install(TARGETS ${PROJECT_NAME} LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} PUBL
 install(FILES ${CMAKE_BINARY_DIR}/truemqtt.pc DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/pkgconfig)
 
 add_subdirectory(example/pubsub)
+add_subdirectory(example/speedtest/pub)
+add_subdirectory(example/speedtest/sub)
+

--- a/example/speedtest/pub/CMakeLists.txt
+++ b/example/speedtest/pub/CMakeLists.txt
@@ -1,0 +1,18 @@
+#
+# Copyright (c) TrueBrain
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+cmake_minimum_required(VERSION 3.16)
+
+project(truemqtt_pubspeed)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+include_directories(SYSTEM ${CMAKE_SOURCE_DIR}/include)
+
+add_executable(${PROJECT_NAME} main.cpp)
+target_link_libraries(${PROJECT_NAME} truemqtt)

--- a/example/speedtest/pub/main.cpp
+++ b/example/speedtest/pub/main.cpp
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) TrueBrain
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <TrueMQTT.h>
+#include <chrono>
+#include <iostream>
+#include <thread>
+#include <unistd.h>
+
+enum TIME_RES
+{
+    T_MICRO,
+    T_MILLI,
+    T_SECONDS
+};
+
+std::uint64_t getEpochUSecs()
+{
+    auto tsUSecs = std::chrono::time_point_cast<std::chrono::microseconds>(std::chrono::system_clock::now());
+    return static_cast<std::uint64_t>(tsUSecs.time_since_epoch().count());
+}
+
+int main(int argc, char* argv[])
+{
+    // Create a connection to a local broker over IPv4 and setup the MQTT-Stack
+    // =========================================================================
+    TrueMQTT::Client client("127.0.0.1", 1883, "SpeedTestPub");
+
+    client.setLogger(TrueMQTT::Client::LogLevel::TRACE, [](TrueMQTT::Client::LogLevel level, std::string message)
+    { std::cout << "Log " << level << ": " << message << std::endl;});
+
+    client.setPublishQueue(TrueMQTT::Client::PublishQueueType::FIFO, 10);
+
+    client.setErrorCallback([](TrueMQTT::Client::Error error, std::string message)
+    { std::cout << "Error " << error << ": " << message << std::endl;});
+
+    client.setLastWill("SpeedTest/lastWill", "SpeedTest Publisher finished", true);
+
+    client.connect();
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    // =========================================================================
+    // 
+    // Keep sending until we press ctrl-c
+
+    // Clear the SpeedTest topic before blowing the fuses
+    client.publish("SpeedTest/", "", false);
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    unsigned int message_number = 0;
+    while(1)
+    {
+        if(message_number < 10)
+        {
+            client.publish("SpeedTest/message[" + std::to_string(message_number) + "]", std::to_string(getEpochUSecs()), false);
+            message_number++;
+        }
+        else
+        {
+            message_number = 0;
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        }
+    }
+
+}

--- a/example/speedtest/sub/CMakeLists.txt
+++ b/example/speedtest/sub/CMakeLists.txt
@@ -1,0 +1,18 @@
+#
+# Copyright (c) TrueBrain
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+cmake_minimum_required(VERSION 3.16)
+
+project(truemqtt_subspeed)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+include_directories(SYSTEM ${CMAKE_SOURCE_DIR}/include)
+
+add_executable(${PROJECT_NAME} main.cpp)
+target_link_libraries(${PROJECT_NAME} truemqtt)

--- a/example/speedtest/sub/main.cpp
+++ b/example/speedtest/sub/main.cpp
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) TrueBrain
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <TrueMQTT.h>
+#include <chrono>
+#include <iostream>
+#include <thread>
+#include <unistd.h>
+#include <vector>
+
+
+enum TIME_RES
+{
+    T_MICRO,
+    T_MILLI,
+    T_SECONDS
+};
+
+std::vector<int> vecTimings;
+
+std::uint64_t getEpochUSecs()
+{
+    auto tsUSecs = std::chrono::time_point_cast<std::chrono::microseconds>(std::chrono::system_clock::now());
+    return static_cast<std::uint64_t>(tsUSecs.time_since_epoch().count());
+}
+
+void processTimes(int epochTat)
+{
+    vecTimings.emplace_back( epochTat );
+
+    if(vecTimings.size() == 10)
+    {
+        float avgTat = 0;
+        int totalTat = 0;
+        for(auto timing : vecTimings)
+        {
+            totalTat += timing;
+        }
+        avgTat = totalTat / vecTimings.size();
+
+        std::cout << "Average : " << std::to_string(static_cast<int>(avgTat)) << " uSecs" << "( " << std::to_string( 1000000 / avgTat ) << " messages / second )" << std::endl;
+
+        // Clear the vector
+        vecTimings.clear();
+    }
+}
+
+int main(int argc, char* argv[])
+{
+    // Create a connection to a local broker over IPv4 and setup the MQTT-Stack
+    // =========================================================================
+    TrueMQTT::Client client("127.0.0.1", 1883, "SpeedTestSub");
+
+    client.setLogger(TrueMQTT::Client::LogLevel::TRACE, [](TrueMQTT::Client::LogLevel level, std::string message)
+    { std::cout << "Log " << level << ": " << message << std::endl;});
+
+    client.setPublishQueue(TrueMQTT::Client::PublishQueueType::FIFO, 10);
+
+    client.setErrorCallback([](TrueMQTT::Client::Error error, std::string message)
+    { std::cout << "Error " << error << ": " << message << std::endl;});
+
+    client.setLastWill("SpeedTest/lastWillSub", "SpeedTest Subscriber finished", true);
+
+    client.connect();
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    // =========================================================================
+    // 
+    // Keep receiving until we press ctrl-c
+
+    client.subscribe("SpeedTest/#", [](const std::string topic, const std::string payload)
+                     {
+                            char *end;
+                            int tat = getEpochUSecs() - std::strtoull(payload.c_str(), &end, 10);
+                            processTimes(tat);
+                     });
+
+    while(1)
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+    }
+
+}


### PR DESCRIPTION
Two binaries, one subscribing, one publishing. Publish epochTime is measured against received epochTime. Per 10 messages, the average Turn-around-Time is calculated and estimates the number of messages per second.
A bit crude setup, but it also shows the usage of the library.